### PR TITLE
add : express-cli support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,22 @@ $ WS_SECRET="secret2" npm start
 - frontend.secret: Secret to be used in the ethstats proxy.
 
 - save-block-txs: Whether block transactions should be written to database.
+
+
+## Run local docker compose environment
+- ``` git clone https://github.com/maticnetwork/reorgs-frontend.git```
+- ```cd reorgs-frontend```
+- ```git checkout localhost```
+- ```sudo docker build -t ethstats-frontend .```
+- ```cd ..```
+- ```sudo docker build -t ethstats-backend .```
+- ```docker-compose up -d```
+- go to ```localhost:8080``` to see the hasura frontend
+- click on ```settings``` on top-right corner
+- click on ```import metadata```
+- select ```hasura_metadata_example.json``` from the root directory of this repo
+- go to ```localhost:3000``` to see the frontend
+
+### Add ethstats flag in bor commands to send bor data to ethstats-backend
+- ```--ethstats <node-name>:<secret>@<ethstats-server-ip>:<ethstats-server-port>```
+- for local setup : ```--ethstats node1:hello@localhost:8000```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,19 +12,21 @@ services:
       POSTGRES_PASSWORD: postgrespassword
   ethstats:
     image: ethstats-backend:latest
+    command: [
+                "server"
+            ]
     ports:
     - "8000:8000"
     depends_on:
     - "postgres"
     environment:
       PERSIST_DAYS : 5
+      COLLECTOR_SECRET : "hello"
     restart: always
   graphql-engine:
     image: hasura/graphql-engine:v2.1.1.cli-migrations-v3
     ports:
     - "8080:8080"
-    volumes:
-    - ./ethstats-hasura/metadata:/hasura-metadata
     depends_on:
     - "ethstats"
     restart: always

--- a/hasura_metadata_example.json
+++ b/hasura_metadata_example.json
@@ -1,0 +1,176 @@
+{
+  "resource_version": 51,
+  "metadata": {
+    "version": 3,
+    "sources": [
+      {
+        "name": "Postgres",
+        "kind": "postgres",
+        "tables": [
+          {
+            "table": {
+              "schema": "public",
+              "name": "block_transactions"
+            },
+            "object_relationships": [
+              {
+                "name": "block",
+                "using": {
+                  "foreign_key_constraint_on": "block_hash"
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "schema": "public",
+              "name": "blocks"
+            },
+            "array_relationships": [
+              {
+                "name": "block_transactions",
+                "using": {
+                  "foreign_key_constraint_on": {
+                    "column": "block_hash",
+                    "table": {
+                      "schema": "public",
+                      "name": "block_transactions"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "schema": "public",
+              "name": "headentry"
+            },
+            "object_relationships": [
+              {
+                "name": "block",
+                "using": {
+                  "manual_configuration": {
+                    "remote_table": {
+                      "schema": "public",
+                      "name": "blocks"
+                    },
+                    "insertion_order": null,
+                    "column_mapping": {
+                      "block_hash": "hash"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "headevent",
+                "using": {
+                  "manual_configuration": {
+                    "remote_table": {
+                      "schema": "public",
+                      "name": "headevents"
+                    },
+                    "insertion_order": null,
+                    "column_mapping": {
+                      "event_id": "event_id"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "schema": "public",
+              "name": "headevents"
+            },
+            "object_relationships": [
+              {
+                "name": "entry",
+                "using": {
+                  "manual_configuration": {
+                    "remote_table": {
+                      "schema": "public",
+                      "name": "headentry"
+                    },
+                    "insertion_order": null,
+                    "column_mapping": {
+                      "event_id": "event_id"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "nodeinfo",
+                "using": {
+                  "foreign_key_constraint_on": "node_id"
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "schema": "public",
+              "name": "nodeinfo"
+            },
+            "array_relationships": [
+              {
+                "name": "headevents",
+                "using": {
+                  "foreign_key_constraint_on": {
+                    "column": "node_id",
+                    "table": {
+                      "schema": "public",
+                      "name": "headevents"
+                    }
+                  }
+                }
+              },
+              {
+                "name": "nodestats",
+                "using": {
+                  "foreign_key_constraint_on": {
+                    "column": "node_id",
+                    "table": {
+                      "schema": "public",
+                      "name": "nodestats"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "table": {
+              "schema": "public",
+              "name": "nodestats"
+            },
+            "object_relationships": [
+              {
+                "name": "nodeinfo",
+                "using": {
+                  "foreign_key_constraint_on": "node_id"
+                }
+              }
+            ]
+          }
+        ],
+        "configuration": {
+          "connection_info": {
+            "use_prepared_statements": true,
+            "database_url": {
+              "from_env": "HASURA_GRAPHQL_DATABASE_URL"
+            },
+            "isolation_level": "read-committed",
+            "pool_settings": {
+              "connection_lifetime": 600,
+              "retries": 1,
+              "idle_timeout": 180,
+              "max_connections": 50
+            }
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
In this PR, we add the support to integrate ethstats-backend with express-cli. Docker compose can be used to spin up environments running the necessary containers on a node of the devnet.